### PR TITLE
chore: Bump os-dns-native to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "typescript": "^4.5.4"
   },
   "optionalDependencies": {
-    "os-dns-native": "^1.1.2",
+    "os-dns-native": "^1.2.0",
     "resolve-mongodb-srv": "^1.1.1"
   }
 }


### PR DESCRIPTION
Not technically required to get this bumped in mongosh because there is no shrinkwrap and os-dns-native has a caret that will cover the version we need, but better to keep up to date