### PR TITLE
fix: pass ca as single string

### DIFF
--- a/src/connect.spec.ts
+++ b/src/connect.spec.ts
@@ -166,8 +166,8 @@ describe('devtools connect', () => {
       mClient.connect.onFirstCall().resolves(mClient);
       const result = await connectMongoClient(uri, { useSystemCA: true }, bus, mClientType as any);
       expect(mClientType.getCalls()).to.have.lengthOf(1);
-      expect(mClientType.getCalls()[0].args[1].ca).to.be.an('array');
-      expect(mClientType.getCalls()[0].args[1].ca[0]).to.include('-----BEGIN CERTIFICATE-----');
+      expect(mClientType.getCalls()[0].args[1].ca).to.be.a('string');
+      expect(mClientType.getCalls()[0].args[1].ca).to.include('-----BEGIN CERTIFICATE-----');
       expect(mClient.connect.getCalls()).to.have.lengthOf(1);
       expect(result).to.equal(mClient);
     });

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -188,7 +188,7 @@ export async function connectMongoClient(
     });
     clientOptions = {
       ...clientOptions,
-      ca
+      ca: ca.join('\n')
     };
     delete clientOptions.useSystemCA;
   }


### PR DESCRIPTION
Otherwise, while the MongoDB driver TypeScript definitions allow for an
array here, anything but the first element would be discarded.