### PR TITLE
feat: allow FLE against non-enterprise servers with bypassQueryAnalysis MONGOSH-1203

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -195,7 +195,9 @@ export async function connectMongoClient(
   }
   delete clientOptions.useSystemCA;
   if (clientOptions.autoEncryption !== undefined &&
-    !clientOptions.autoEncryption.bypassAutoEncryption) {
+    !clientOptions.autoEncryption.bypassAutoEncryption &&
+    // @ts-expect-error waiting for driver release
+    !clientOptions.autoEncryption.bypassQueryAnalysis) {
     // connect first without autoEncryption and serverApi options.
     const optionsWithoutFLE = { ...clientOptions };
     delete optionsWithoutFLE.autoEncryption;


### PR DESCRIPTION
The `bypassQueryAnalysis: true` should allow using FLE 2 against non-enterprise servers and skip data encryption.