### PR TITLE
feat: add error message when connection fails due to IP access issues COMPASS-6842

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "sinon-chai": "^3.7.0",
     "ts-node": "^10.2.1",
     "ts-sinon": "^2.0.1",
-    "typescript": "^4.5.4"
+    "typescript": "^5.0.4"
   },
   "optionalDependencies": {
     "os-dns-native": "^1.2.0",

--- a/src/connect.spec.ts
+++ b/src/connect.spec.ts
@@ -299,6 +299,19 @@ describe('devtools connect', () => {
     });
   });
 
+  describe('atlas', () => {
+    it('shows the whitelist issue message when errors to connect to Atlas', async() => {
+      const uri = 'mongodb://compass-data-sets-shard-00-00.e06dc.mongodb.net/?connectTimeoutMS=1&serverSelectionTimeoutMS=1';
+      const bus = new EventEmitter();
+      try {
+        await connectMongoClient(uri, defaultOpts, bus, MongoClient);
+      } catch (e: any) {
+        return expect(e.message.toLowerCase()).to.include('it looks like this is a mongodb atlas cluster');
+      }
+      expect.fail('Failed to throw expected error');
+    });
+  });
+
   describe('isHumanOidcFlow', function() {
     it('returns false by default', function() {
       expect(isHumanOidcFlow('mongodb://example/', {})).to.equal(false);

--- a/src/connect.spec.ts
+++ b/src/connect.spec.ts
@@ -300,7 +300,7 @@ describe('devtools connect', () => {
   });
 
   describe('atlas', () => {
-    it('shows the ensure that your network access list allows connections from your ip error', async() => {
+    it('shows an error reminding the user to ensure that their network access list allows connections from their ip', async() => {
       const uri = 'mongodb://compass-data-sets-shard-00-00.e06dc.mongodb.net/?connectTimeoutMS=1&serverSelectionTimeoutMS=1';
       const bus = new EventEmitter();
       try {

--- a/src/connect.spec.ts
+++ b/src/connect.spec.ts
@@ -300,7 +300,7 @@ describe('devtools connect', () => {
   });
 
   describe('atlas', () => {
-    it('shows the whitelist issue message when errors to connect to Atlas', async() => {
+    it('shows the ensure that your network access list allows connections from your ip error', async() => {
       const uri = 'mongodb://compass-data-sets-shard-00-00.e06dc.mongodb.net/?connectTimeoutMS=1&serverSelectionTimeoutMS=1';
       const bus = new EventEmitter();
       try {

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -79,7 +79,7 @@ async function connectWithFailFast(uri: string, client: MongoClient, logger: Con
       await failEarlyClosePromise;
       throw failedConnections.values().next().value; // Just use the first failure.
     } else if (isAtlas(uri)) {
-      (err as Error).message =  'It looks like this is a MongoDB Atlas cluster. Please ensure that your IP whitelist allows connections from your network.';
+      (err as Error).message = 'It looks like this is a MongoDB Atlas cluster. Please ensure that your IP whitelist allows connections from your network.';
     }
     throw err;
   } finally {

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -79,13 +79,17 @@ async function connectWithFailFast(uri: string, client: MongoClient, logger: Con
   client.addListener('serverHeartbeatSucceeded', heartbeatSucceededListener);
   try {
     await client.connect();
-  } catch (err: unknown) {
-    let connectErr = err;
+  } catch (error: unknown) {
+    let connectErr = error;
     if (failEarlyClosePromise !== null) {
       await failEarlyClosePromise;
       connectErr = failedConnections.values().next().value; // Just use the first failure.
     }
-    if ((connectErr as any)?.constructor?.name === 'MongoServerSelectionError' && isAtlas(uri)) {
+    if (
+      typeof connectErr === 'object' &&
+      connectErr?.constructor.name === 'MongoServerSelectionError' &&
+      isAtlas(uri)
+    ) {
       (connectErr as Error).message = `${(connectErr as Error).message}. It looks like this is a MongoDB Atlas cluster. Please ensure that your Network Access List allows connections from your IP.`;
     }
     throw connectErr;

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -79,13 +79,13 @@ async function connectWithFailFast(uri: string, client: MongoClient, logger: Con
   client.addListener('serverHeartbeatSucceeded', heartbeatSucceededListener);
   try {
     await client.connect();
-  } catch (err: any) {
+  } catch (err: unknown) {
     if (failEarlyClosePromise !== null) {
       await failEarlyClosePromise;
       throw failedConnections.values().next().value; // Just use the first failure.
     }
-    if (err.constructor?.name === 'MongoServerSelectionError' && isAtlas(uri)) {
-      err.message = `${err.message} It looks like this is a MongoDB Atlas cluster. Please ensure that your Network Access List allows connections from your IP.`;
+    if ((err as any)?.constructor?.name === 'MongoServerSelectionError' && isAtlas(uri)) {
+      (err as Error).message = `${(err as Error).message}. It looks like this is a MongoDB Atlas cluster. Please ensure that your Network Access List allows connections from your IP.`;
     }
     throw err;
   } finally {

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -17,6 +17,8 @@ import { StateShareClient, StateShareServer } from './ipc-rpc-state-share';
 import ConnectionString, { CommaAndColonSeparatedRecord } from 'mongodb-connection-string-url';
 import EventEmitter from 'events';
 
+const isAtlas = (str: string) => str.match(/mongodb.net[:/]/i);
+
 export class MongoAutoencryptionUnavailable extends Error {
   constructor() {
     super('Automatic encryption is only available with Atlas and MongoDB Enterprise');
@@ -76,6 +78,8 @@ async function connectWithFailFast(uri: string, client: MongoClient, logger: Con
     if (failEarlyClosePromise !== null) {
       await failEarlyClosePromise;
       throw failedConnections.values().next().value; // Just use the first failure.
+    } else if (isAtlas(uri)) {
+      (err as Error).message =  'It looks like this is a MongoDB Atlas cluster. Please ensure that your IP whitelist allows connections from your network.';
     }
     throw err;
   } finally {

--- a/src/ipc-rpc-state-share.ts
+++ b/src/ipc-rpc-state-share.ts
@@ -109,7 +109,7 @@ export abstract class RpcServer {
 
       response = { status: 200, ...await this.handleRpc(content) };
     } catch (err) {
-      response = { status: 500, error: err && typeof err === 'object' && 'message' in err ? (err as Error).message : String(err) };
+      response = { status: 500, error: err && typeof err === 'object' && 'message' in err ? err.message : String(err) };
     }
     res.statusCode = response.status;
     const payload = new TextEncoder().encode(JSON.stringify(response));

--- a/src/ipc-rpc-state-share.ts
+++ b/src/ipc-rpc-state-share.ts
@@ -108,7 +108,7 @@ export abstract class RpcServer {
         req.headers['x-signature'], this.hmacKey));
 
       response = { status: 200, ...await this.handleRpc(content) };
-    } catch (err) {
+    } catch (err: unknown) {
       response = { status: 500, error: err && typeof err === 'object' && 'message' in err ? err.message : String(err) };
     }
     res.statusCode = response.status;

--- a/src/ipc-rpc-state-share.ts
+++ b/src/ipc-rpc-state-share.ts
@@ -109,7 +109,7 @@ export abstract class RpcServer {
 
       response = { status: 200, ...await this.handleRpc(content) };
     } catch (err) {
-      response = { status: 500, error: err && typeof err === 'object' && 'message' in err ? err.message : String(err) };
+      response = { status: 500, error: err && typeof err === 'object' && 'message' in err ? (err as Error).message : String(err) };
     }
     res.statusCode = response.status;
     const payload = new TextEncoder().encode(JSON.stringify(response));


### PR DESCRIPTION
Detect by URI if a user tries to connect to Atlas. If errors, overwrite the error message to help users troubleshoot the issue and point to the fact, that their IP might not be whitelisted in the Atlas network settings.