### PR TITLE
fix: remove listener cap for OIDC plugin logger, remove listeners when unused MONGOSH-1479

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
   "peerDependencies": {
     "mongodb": "^5.4.0",
     "mongodb-log-writer": "^1.2.0",
-    "@mongodb-js/oidc-plugin": "^0.2.3"
+    "@mongodb-js/oidc-plugin": "^0.2.4"
   },
   "devDependencies": {
     "@mongodb-js/compass-components": "^1.6.0",
-    "@mongodb-js/oidc-plugin": "^0.2.3",
+    "@mongodb-js/oidc-plugin": "^0.2.4",
     "@types/lodash.merge": "^4.6.7",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.4.10",

--- a/src/connect.spec.ts
+++ b/src/connect.spec.ts
@@ -231,9 +231,10 @@ describe('devtools connect', () => {
       const mClient = new FakeMongoClient();
       const mClientType = sinon.stub().returns(mClient);
       let rejectConnect: (err: Error) => void;
-      mClient.close = sinon.stub().callsFake(() => {
+      const closeSpy = sinon.stub().callsFake(() => {
         rejectConnect(new Error('discarded error'));
       });
+      mClient.close = closeSpy;
       mClient.connect = () => new Promise((resolve, reject) => {
         rejectConnect = reject;
         setImmediate(() => {
@@ -250,7 +251,7 @@ describe('devtools connect', () => {
       try {
         await connectMongoClient(uri, defaultOpts, bus, mClientType as any);
       } catch (e) {
-        expect((mClient.close as any).getCalls()).to.have.lengthOf(1);
+        expect((closeSpy as any).getCalls()).to.have.lengthOf(1);
         return expect(e).to.equal(err);
       }
       expect.fail('Failed to throw expected error');

--- a/src/connect.spec.ts
+++ b/src/connect.spec.ts
@@ -295,7 +295,11 @@ describe('devtools connect', () => {
       const bus = new EventEmitter();
       const { client } = await connectMongoClient(process.env.MONGODB_URI ?? '', defaultOpts, bus, MongoClient);
       expect((await client.db('admin').command({ ping: 1 })).ok).to.equal(1);
+
+      const onCloseStub = sinon.stub();
+      client.on('close', onCloseStub);
       await client.close();
+      expect(onCloseStub.getCalls()).to.have.lengthOf(1);
     });
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,7 @@ export type ConnectEventArgs<K extends keyof ConnectEventMap> = ConnectEventMap[
 export interface ConnectLogEmitter {
   // TypeScript uses something like this itself for its EventTarget definitions.
   on<K extends keyof ConnectEventMap>(event: K, listener: ConnectEventMap[K]): this;
+  off?<K extends keyof ConnectEventMap>(event: K, listener: ConnectEventMap[K]): this;
   once<K extends keyof ConnectEventMap>(event: K, listener: ConnectEventMap[K]): this;
   emit<K extends keyof ConnectEventMap>(event: K, ...args: ConnectEventArgs<K>): unknown;
 }


### PR DESCRIPTION
Do not emit warnings when attaching too many `MongoClient`s to the same `DevtoolsConnectState` instance, and remove the listeners once their corresponding `MongoClient`s have been closed.

As part of this, ensure that our `MongoClient` instances always emit `'close'` events, which are currently part of the driver’s types but not actually being emitted.