### PR TITLE
chore: update oidc plugin, handle redirecting state in redirect handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,17 +36,17 @@
   "license": "Apache-2.0",
   "dependencies": {
     "lodash.merge": "^4.6.2",
-    "system-ca": "^1.0.2",
-    "mongodb-connection-string-url": "^2.6.0"
+    "mongodb-connection-string-url": "^2.6.0",
+    "system-ca": "^1.0.2"
   },
   "peerDependencies": {
+    "@mongodb-js/oidc-plugin": "^0.3.0",
     "mongodb": "^5.4.0",
-    "mongodb-log-writer": "^1.2.0",
-    "@mongodb-js/oidc-plugin": "^0.2.4"
+    "mongodb-log-writer": "^1.2.0"
   },
   "devDependencies": {
     "@mongodb-js/compass-components": "^1.6.0",
-    "@mongodb-js/oidc-plugin": "^0.2.4",
+    "@mongodb-js/oidc-plugin": "^0.3.0",
     "@types/lodash.merge": "^4.6.7",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.4.10",

--- a/src/oidc/handler.ts
+++ b/src/oidc/handler.ts
@@ -9,6 +9,13 @@ export function oidcServerRequestHandler(
   const { productDocsLink, productName } = options;
   const { res, result, status } = info;
   res.statusCode = status;
+
+  if (result === 'redirecting') {
+    res.setHeader('Location', info.location);
+    res.end();
+    return;
+  }
+
   // This CSP is fairly restrictive. Since we are sending static pages only, the security
   // effects of this are limited, but this is also helpful for verifying that the generated
   // pages do not unintentionally rely on external resources (which they should never do).


### PR DESCRIPTION
I think that inconsistency is what's breaking tests in https://github.com/mongodb-js/compass/pull/4655 but I spent like 3 hours trying to run those OIDC tests locally and didn't succeed, so I couldn't really confirm this (but that's the only issue that comes to mind). Will have to publish, update the dependency and run the e2e tests in compass monorepo to make sure