### PR TITLE
fix: drop saslprep from expected deps, add socks

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@mongodb-js/oidc-plugin": "^0.3.0",
-    "mongodb": "^5.4.0 || ^6.0.0",
+    "mongodb": "^5.8.1 || ^6.0.0",
     "mongodb-log-writer": "^1.2.0"
   },
   "devDependencies": {
@@ -65,7 +65,7 @@
     "eslint-plugin-standard": "^5.0.0",
     "gen-esm-wrapper": "^1.1.0",
     "mocha": "^9.1.1",
-    "mongodb": "^5.4.0 || ^6.0.0",
+    "mongodb": "^5.8.1 || ^6.0.0",
     "mongodb-log-writer": "^1.2.0",
     "nyc": "^15.1.0",
     "react": "^17.0.2",

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -163,9 +163,9 @@ async function resolveMongodbSrv(uri: string, logger: ConnectLogEmitter): Promis
 function detectAndLogMissingOptionalDependencies(logger: ConnectLogEmitter) {
   // These need to be literal require('string') calls for bundling purposes.
   try {
-    require('saslprep');
+    require('socks');
   } catch (error: any) {
-    logger.emit('devtools-connect:missing-optional-dependency', { name: 'saslprep', error });
+    logger.emit('devtools-connect:missing-optional-dependency', { name: 'socks', error });
   }
   try {
     require('mongodb-client-encryption');


### PR DESCRIPTION
Do not expect `saslprep` as an optional dependency anymore, it’s not necessary, but do add `socks` since that is a new optional dependency in the 6.x driver that we need in our products.